### PR TITLE
chore: setup.py entry typo

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     ],
     entry_points={
         'console_scripts': [
-            'samples-filter=objects.__main__.py:main',
+            'samples-filter=objects.__main__:main',
         ],
     },
     author='Aliaksei Bialiauski',


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the entry point in `setup.py` to fix a typo, pointing to the correct location of the `main` function in `objects.__main__` module.

### Detailed summary
- Updated the entry point in `setup.py` to correctly reference the `main` function in `objects.__main__` module.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->