### PR TITLE
feat(#23): create pipeline dir

### DIFF
--- a/objects/input.py
+++ b/objects/input.py
@@ -33,10 +33,6 @@ class Input:
         self.name = name
 
     def copy(self):
-        # @todo #19:25min Prepare files in /pipeline directory.
-        #  We should create them before running actual processing.
-        #  For now we need to manually create files.
-        #  Don't forget to remove this puzzle.
         with open(self.name, "r") as input, open(self.DESTINATION, "w", newline="") as pipe:
             reader = csv.DictReader(input)
             writer = csv.DictWriter(

--- a/objects/pre_filter.py
+++ b/objects/pre_filter.py
@@ -23,10 +23,15 @@
 """
 Prepares outputs before running filters.
 """
+import os.path
+
+
 class PreFilter:
     def __init__(self, out):
         self.out = out
 
     def prepare(self):
+        if not os.path.exists("pipeline"):
+            os.makedirs("pipeline")
         with open(self.out, "w") as file:
             file.write("")

--- a/tests/test_pre_filter.py
+++ b/tests/test_pre_filter.py
@@ -1,0 +1,42 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2024 Aliaksei Bialiauski
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""
+Test case for PreFilter.
+"""
+import os
+import unittest
+from objects.pre_filter import PreFilter
+
+
+class TestPreFilter(unittest.TestCase):
+    def setUp(self):
+        self.out = "test_output.csv"
+        self.pre = PreFilter(self.out)
+
+    def tearDown(self):
+        os.rmdir("pipeline")
+        os.remove(self.out)
+
+    def test_creates_pipeline_dir(self):
+        self.pre.prepare()
+        self.assertTrue(os.path.exists("pipeline"))


### PR DESCRIPTION
closes #23

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add a test case for the `PreFilter` class in the `objects/pre_filter.py` file.

### Detailed summary
- Added a test case for `PreFilter`
- Included license information
- Imported necessary modules in the test file
- Implemented setup and teardown methods
- Added a test to check if `pipeline` directory is created

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->