### PR TITLE
feat(#24): fetch readme from raw github instead of api

### DIFF
--- a/objects/input.py
+++ b/objects/input.py
@@ -61,7 +61,7 @@ class Input:
                 issues = row["open_issues_count"]
                 description = row["description"]
                 topics = row["topics"]
-                readme = Readme(repo).asText()
+                readme = Readme(repo, branch).asText()
                 out = {
                     "full_name": repo,
                     "default_branch": branch,

--- a/objects/readme.py
+++ b/objects/readme.py
@@ -23,25 +23,18 @@
 """
 GitHub Readme.
 """
-import base64
-
 import requests
 
-
 class Readme:
-    def __init__(self, repo):
+    def __init__(self, repo, branch):
         self.repo = repo
+        self.branch = branch
 
-    # @todo #19:45min Use raw.githubusercontent.com instead of api.github.com.
-    #  We should use static GitHub content hosting instead of their API
-    #  in order to prevent problems with rate limits.
-    #  Don't forget to remove this puzzle.
     def asText(self):
         response = requests.get(
-            f"https://api.github.com/repos/{self.repo}/readme",
-            headers={"Accept": "application/vnd.github.v3+json"}
+            f"https://raw.githubusercontent.com/{self.repo}/{self.branch}/README.md",
         )
         if response.status_code == 200:
-            return base64.b64decode(response.json()["content"]).decode("utf-8")
+            return response.text
         else:
-            print(f"Failed to fetch README for {self.repo}")
+            print(f"Failed to fetch README for {self.repo}@{self.branch}")


### PR DESCRIPTION
closes #24

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `Readme` class in `readme.py` to fetch README content from GitHub using raw content URL instead of the API, now accepting a branch parameter.

### Detailed summary
- Updated `Readme` class to accept `branch` parameter for fetching README.
- Changed README fetching URL to use raw.githubusercontent.com.
- Improved error message to include the branch name when failing to fetch README.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->