### PR TITLE
chore: remove *.csv, *.tex

### DIFF
--- a/model/data/Makefile
+++ b/model/data/Makefile
@@ -29,7 +29,7 @@
 SHELL := bash
 
 clean:
-	rm -f dataset.csv repos.csv examples.csv samples.csv guides.csv repos.tex examples.tex samples.tex guides.tex
+	rm -f *.csv *.tex
 
 # Build new dataset.
 dataset:


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR simplifies the `clean` target in the `Makefile` by using wildcard patterns to remove all `csv` and `tex` files. 

### Detailed summary
- Updated `clean` target to use wildcard patterns to remove all `csv` and `tex` files instead of listing them individually.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->