### PR TITLE
feat(#89): gem install

### DIFF
--- a/.github/workflows/dataset.yml
+++ b/.github/workflows/dataset.yml
@@ -39,6 +39,9 @@ jobs:
         with:
           python-version: "3.9"
       - run: |
+          gem install fileutils
+          gem install slop
+          gem install octokit
           make install check
           cd model
           make data/dataset


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds gem installations for `fileutils`, `slop`, and `octokit` to the workflow, along with the existing `make` commands for installation and data processing.

### Detailed summary
- Added gem installations for `fileutils`, `slop`, and `octokit` in the workflow
- Updated commands to include gem installations before running `make` commands

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->