### PR TITLE
feat(#89, #90): pull csv from dataset branch, train random-forest on trigger

### DIFF
--- a/.github/workflows/random-forest.yml
+++ b/.github/workflows/random-forest.yml
@@ -19,39 +19,35 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-
-.SHELLFLAGS: -e -o pipefail -c
-.ONESHELL:
-.PHONY: $(DATA_FOLDER)/clean $(DATA_FOLDER)/dataset trainrf transformer
-.SILENT:
-
-## The shell to use.
-SHELL := bash
-
-# Data folder.
-DATA_FOLDER := data
-
-# Clean .csv and .tex files.
-$(DATA_FOLDER)/clean:
-	cd $(DATA_FOLDER) && \
-	rm -f *.csv *.tex
-
-# Build new dataset.
-$(DATA_FOLDER)/dataset:
-	cd $(DATA_FOLDER) && \
-	ruby discover-repos.rb --total=750 --csv=repos.csv --tex=repos.tex
-	ruby discover-repos.rb --total=84 --query-append=examples --min-stars=20 --csv=examples.csv --tex=examples.tex
-	ruby discover-repos.rb --total=83 --query-append=samples --min-stars=20 --csv=samples.csv --tex=samples.tex
-	ruby discover-repos.rb --total=83 --query-append=guides --min-stars=20 --csv=guides.csv --tex=guides.tex
-	python3 combine.py
-	python3 fetch.py
-	python3 remove_branch.py
-	python3 label.py
-
-# Train model with Random-Forest algorithm.
-random-forest:
-	python3 random-forest.py
-
-# Train text transformer.
-transformer:
-	python3 transformer.py
+---
+name: random-forest
+on:
+  workflow_dispatch:
+permissions: write-all
+jobs:
+  train:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - run: sudo apt-get install -y python3-pygments && sudo pip3 install pygments
+      - run: sudo apt-get -y install ghostscript
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+      - uses: actions/setup-python@v3
+        with:
+          python-version: "3.9"
+      - run: |
+          make install cov check
+          cd model
+          make random-forest
+          mkdir random-forest
+          cp rf-classifier.joblib random-forest
+          cp rf-vec.joblib random-forest
+      - uses: JamesIves/github-pages-deploy-action@v4.6.0
+        with:
+          branch: random-forest
+          folder: model/random-forest
+          clean: false
+        if: github.ref == 'refs/heads/master'

--- a/model/README.md
+++ b/model/README.md
@@ -94,8 +94,7 @@ Training dataset is a [CSV] file with the following columns:
 * `label` for labeling repositories as real (`0`) and sample (`1`)
 
 Full dataset used for model training is located [here](https://github.com/h1alexbel/samples-filter/blob/dataset/train.csv).
-To refresh it, [dataset workflow](https://github.com/h1alexbel/samples-filter/actions/workflows/dataset.yml)
-triggering is needed. 
+To refresh it, trigger [dataset workflow](https://github.com/h1alexbel/samples-filter/actions/workflows/dataset.yml).
 
 You will need [Python 3.9+] and [Ruby 3.3+] installed.
 

--- a/model/README.md
+++ b/model/README.md
@@ -51,7 +51,7 @@ is a real project/framework/library.
 To train Random-Forest model, run this script:
 
 ```bash
-make trainrf
+make random-forest
 ```
 
 After training successfully ended you should have `.joblib` files for both,
@@ -93,7 +93,9 @@ Training dataset is a [CSV] file with the following columns:
 * `commits` for number of commits in the repository
 * `label` for labeling repositories as real (`0`) and sample (`1`)
 
-Full dataset used for model training is located [here](https://huggingface.co/datasets/h1alexbel/github-samples).
+Full dataset used for model training is located [here](https://github.com/h1alexbel/samples-filter/blob/dataset/train.csv).
+To refresh it, [dataset workflow](https://github.com/h1alexbel/samples-filter/actions/workflows/dataset.yml)
+triggering is needed. 
 
 You will need [Python 3.9+] and [Ruby 3.3+] installed.
 

--- a/model/random-forest.py
+++ b/model/random-forest.py
@@ -32,10 +32,9 @@ from joblib import dump
 
 nltk.download("punkt")
 nltk.download("stopwords")
-# @todo #75:30min Read CSV file from HuggingFace.
-#  We should fetch the whole CSV file uploaded to HuggingFace.
-#  This will help us to use the dataset without building it each time.
-frame = pandas.read_csv("data/train.csv")
+frame = pandas.read_csv(
+    "https://raw.githubusercontent.com/h1alexbel/samples-filter/dataset/train.csv"
+)
 
 
 def preprocess(text):
@@ -77,9 +76,5 @@ print(classification_report(l_test, predicted))
 
 target = "rf-classifier.joblib"
 print(f"Saving the model to... {target}")
-# @todo #75:40min Upload model and vectorizer as .joblib files to some file
-#  storage. In order to reuse already trained model, we should upload those
-#  files to file storage, or maybe even to HuggingFace. After it's uploaded we
-#  can fetch it and use #load function.
 dump(model, target)
-dump(vectorizer, "rf/rf-vec.joblib")
+dump(vectorizer, "rf-vec.joblib")


### PR DESCRIPTION
ref #89 ref #90

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the model training process by renaming the `trainrf` target to `random-forest`, updating dataset sources, and refining the workflow for model deployment.

### Detailed summary
- Renamed `trainrf` target to `random-forest` in `Makefile`
- Updated dataset source link in `README.md`
- Updated dataset loading in `random-forest.py`
- Refactored model saving in `random-forest.py`
- Added licensing information in `random-forest.yml`
- Enhanced workflow for model deployment in `random-forest.yml`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->