### PR TITLE
feat(#146): pre_readme.py, pre_description.py, pre_topics.py

### DIFF
--- a/models/.gitignore
+++ b/models/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+*.egg-info/

--- a/models/model/pre_description.py
+++ b/models/model/pre_description.py
@@ -1,0 +1,43 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2024 Aliaksei Bialiauski
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import re
+
+from nltk import word_tokenize, WordNetLemmatizer
+from nltk.corpus import stopwords
+
+"""
+Repository description preprocessing.
+"""
+
+
+class PreDescription:
+    def __init__(self, text):
+        self.text = text
+
+    def tokens(self):
+        lower = self.text.lower()
+        no_puncts = re.sub(r'[^\w\s]', '', lower)
+        tokens = word_tokenize(no_puncts)
+        stops = set(stopwords.words('english'))
+        filtered = [word for word in tokens if word not in stops]
+        lemmatizer = WordNetLemmatizer()
+        return [lemmatizer.lemmatize(word, pos='v') for word in filtered]

--- a/models/model/pre_name.py
+++ b/models/model/pre_name.py
@@ -24,6 +24,10 @@ import re
 from nltk.corpus import stopwords
 from nltk.stem import WordNetLemmatizer
 
+"""
+Repository name preprocessing.
+"""
+
 
 class PreName:
     def __init__(self, origin):

--- a/models/model/pre_name.py
+++ b/models/model/pre_name.py
@@ -35,8 +35,7 @@ class PreName:
 
     def tokens(self):
         name = self.origin.lower()
-        name = re.split(r'[/\-_]', name)
-        tokens = name
+        tokens = re.split(r'[/\-_]', name)
         stops = set(stopwords.words('english'))
         filtered = [word for word in tokens if word not in stops]
         lemmatizer = WordNetLemmatizer()

--- a/models/model/pre_readme.py
+++ b/models/model/pre_readme.py
@@ -1,0 +1,45 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2024 Aliaksei Bialiauski
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import re
+from nltk import WordNetLemmatizer
+from nltk.corpus import stopwords
+from nltk.tokenize import word_tokenize
+
+"""
+Repository README preprocessing.
+"""
+
+
+class PreReadme:
+    def __init__(self, content):
+        self.content = content
+
+    def tokens(self):
+        lower = self.content.lower()
+        no_tags = re.sub(r'<.*?>', '', lower)
+        no_puncts = re.sub(r'[^\w\s]', '', no_tags)
+        tokens = word_tokenize(no_puncts)
+        stops = set(stopwords.words('english'))
+        stops.update(['b', 'bash'])
+        filtered = [word for word in tokens if word not in stops]
+        lemmatizer = WordNetLemmatizer()
+        return [lemmatizer.lemmatize(word, pos='v') for word in filtered]

--- a/models/model/pre_topics.py
+++ b/models/model/pre_topics.py
@@ -20,21 +20,23 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 import re
+
 from nltk.corpus import stopwords
-from nltk.stem import PorterStemmer, WordNetLemmatizer
+from nltk.stem import WordNetLemmatizer
 
-topics = ["java", "examples", "flink", "streaming"]
-topics = [topic.lower() for topic in topics]
+"""
+Repository topics preprocessing.
+"""
 
-topics = [re.sub(r'[^a-z0-9\s]', '', topic) for topic in topics]
-stop_words = set(stopwords.words('english'))
-topics = [topic for topic in topics if topic not in stop_words]
 
-lemmatizer = WordNetLemmatizer()
-lemmatized = [lemmatizer.lemmatize(topic) for topic in topics]
+class PreTopics:
+    def __init__(self, topics):
+        self.topics = topics
 
-# @todo #140:25min F
-ready = lemmatized
-
-print("Original Topics:", topics)
-print("Processed Topics:", ready)
+    def tokens(self):
+        lower = [topic.lower() for topic in self.topics]
+        split = [re.sub(r'[^a-z0-9\s]', '', topic) for topic in lower]
+        stops = set(stopwords.words('english'))
+        split = [topic for topic in split if topic not in stops]
+        lemmatizer = WordNetLemmatizer()
+        return [lemmatizer.lemmatize(topic) for topic in split]

--- a/models/model/pre_topics.py
+++ b/models/model/pre_topics.py
@@ -1,0 +1,40 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2024 Aliaksei Bialiauski
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import re
+from nltk.corpus import stopwords
+from nltk.stem import PorterStemmer, WordNetLemmatizer
+
+topics = ["java", "examples", "flink", "streaming"]
+topics = [topic.lower() for topic in topics]
+
+topics = [re.sub(r'[^a-z0-9\s]', '', topic) for topic in topics]
+stop_words = set(stopwords.words('english'))
+topics = [topic for topic in topics if topic not in stop_words]
+
+lemmatizer = WordNetLemmatizer()
+lemmatized = [lemmatizer.lemmatize(topic) for topic in topics]
+
+# @todo #140:25min F
+ready = lemmatized
+
+print("Original Topics:", topics)
+print("Processed Topics:", ready)

--- a/models/model_tests/test_pre_description.py
+++ b/models/model_tests/test_pre_description.py
@@ -21,19 +21,19 @@
 # SOFTWARE.
 import unittest
 
-from model.pre_name import PreName
+from model.pre_description import PreDescription
 
 """
-Test cases for PreName.
+Test cases for PreDescription.
 """
 
 
-class TestPreName(unittest.TestCase):
+class TestPreDescription(unittest.TestCase):
 
-    def test_preprocesses_name(self):
-        input = "streaming-with-flink/examples-java"
-        tokens = PreName(input).tokens()
-        expected = ["streaming", "flink", "example", "java"]
+    def test_preprocess_description(self):
+        input = "This repository hosts Java examples"
+        tokens = PreDescription(input).tokens()
+        expected = ["repository", "host", "java", "examples"]
         self.assertEqual(
             tokens,
             expected,

--- a/models/model_tests/test_pre_readme.py
+++ b/models/model_tests/test_pre_readme.py
@@ -1,0 +1,55 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2024 Aliaksei Bialiauski
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import unittest
+
+from pre_readme import PreReadme
+
+"""
+Test cases for PreReadme.
+"""
+
+
+class TestPreReadme(unittest.TestCase):
+
+    def test_preprocesses_readme_in_tokens(self):
+        tokens = PreReadme("""
+            ## Java Examples for Stream Processing with Apache Flink
+
+            This repository hosts Java code examples for
+            ["Stream Processing with Apache Flink"](//link).
+
+            **Note:** The Java examples are not comlete yet. <br>
+            The [Scala examples](#scala) placed here.
+            """).tokens()
+        expected = [
+            "java", "examples", "stream", "process",
+            "apache", "flink", "repository", "host",
+            "java", "code", "examples", "stream",
+            "process", "apache", "flinklink", "note",
+            "java", "examples", "comlete", "yet",
+            "scala", "examplesscala", "place"
+        ]
+        self.assertEqual(
+            tokens,
+            expected,
+            f"received tokens {tokens} do not match with expected {expected}"
+        )

--- a/models/model_tests/test_pre_readme.py
+++ b/models/model_tests/test_pre_readme.py
@@ -37,7 +37,7 @@ class TestPreReadme(unittest.TestCase):
             This repository hosts Java code examples for
             ["Stream Processing with Apache Flink"](//link).
 
-            **Note:** The Java examples are not comlete yet. <br>
+            **Note:** The Java examples are not complete yet. <br>
             The [Scala examples](#scala) placed here.
             """).tokens()
         expected = [
@@ -45,7 +45,7 @@ class TestPreReadme(unittest.TestCase):
             "apache", "flink", "repository", "host",
             "java", "code", "examples", "stream",
             "process", "apache", "flinklink", "note",
-            "java", "examples", "comlete", "yet",
+            "java", "examples", "complete", "yet",
             "scala", "examplesscala", "place"
         ]
         self.assertEqual(

--- a/models/model_tests/test_pre_readme.py
+++ b/models/model_tests/test_pre_readme.py
@@ -21,7 +21,7 @@
 # SOFTWARE.
 import unittest
 
-from pre_readme import PreReadme
+from model.pre_readme import PreReadme
 
 """
 Test cases for PreReadme.

--- a/models/model_tests/test_pre_topics.py
+++ b/models/model_tests/test_pre_topics.py
@@ -1,0 +1,40 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2024 Aliaksei Bialiauski
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import unittest
+
+from model.pre_topics import PreTopics
+
+"""
+Test cases for PreTopics.
+"""
+
+
+class TestPreTopics(unittest.TestCase):
+
+    def test_preprocesses_topics(self):
+        tokens = PreTopics(["java", "examples", "flink", "streaming"]).tokens()
+        expected = ["java", "example", "flink", "streaming"]
+        self.assertEqual(
+            tokens,
+            expected,
+            f"received tokens {tokens} do not match with expected {expected}"
+        )


### PR DESCRIPTION
closes #146

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances text preprocessing in the models by adding new classes for repository name, topics, description, and README. It also includes corresponding test cases.

### Detailed summary
- Added `PreName`, `PreTopics`, `PreDescription`, and `PreReadme` classes
- Implemented text preprocessing for repository name, topics, description, and README
- Added corresponding test cases for each preprocessing class

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->